### PR TITLE
Optimize reading struct arrays

### DIFF
--- a/CrossArc/ARC.cs
+++ b/CrossArc/ARC.cs
@@ -24,319 +24,300 @@ namespace CrossArc
         public long SubFileInformationOffset;
     }
 
-
     public class ARC
     {
-        public static string FilePath = "data.arc";
+        public string FilePath { get; }
 
-        private static int ArcVersion = 1;
+        private int arcVersion = 1;
 
-        public static _sArcHeader Header;
-        public static _sDirectoryOffsets[] DirectoryOffsets_1;
-        public static _sDirectoryOffsets[] DirectoryOffsets_2;
-        public static _sDirectoryList[] DirectoryLists;
-        public static _sFileInformation[] FileInformation;
-        public static _sFolderHashIndex[] HashFolderCounts;
-        public static _SubFileInfo[] SubFileInformation_1;
-        public static _SubFileInfo[] SubFileInformation_2;
+        private _sArcHeader header;
+        private _sDirectoryOffsets[] directoryOffsets1;
+        private _sDirectoryOffsets[] directoryOffsets2;
+        private _sDirectoryList[] directoryLists;
+        private _sFileInformation[] fileInformation;
+        private _sFolderHashIndex[] hashFolderCounts;
+        private _SubFileInfo[] subFileInformation1;
+        private _SubFileInfo[] subFileInformation2;
 
         // Stream Stuff
-        public static _sStreamHashToName[] StreamHashToName;
-        public static _sStreamNameToHash[] StreamNameToHash;
-        public static _sStreamIndexToFile[] StreamIndexToFile;
-        public static _sStreamOffset[] StreamOffsets;
+        private _sStreamHashToName[] streamHashToName;
+        private _sStreamNameToHash[] streamNameToHash;
+        private _sStreamIndexToFile[] streamIndexToFile;
+        private _sStreamOffset[] streamOffsets;
 
         // Arc v2 exclusive
-        public static _sFileInformationV2[] FileInformationV2;
-        public static _sFileInformationPath[] FileInformationPath;
-        public static _sFileInformationIndex[] FileInformationIndex;
-        public static _sFileInformationSubIndex[] FileInformationSubIndex;
+        private _sFileInformationV2[] fileInformationV2;
+        private _sFileInformationPath[] fileInformationPath;
+        private _sFileInformationIndex[] fileInformationIndex;
+        private _sFileInformationSubIndex[] fileInformationSubIndex;
 
         // for speed
-        public static Dictionary<uint, _sDirectoryList> FolderHashDict;
-        public static Dictionary<int, _sDirectoryOffsets> ChunkHash1 = new Dictionary<int, _sDirectoryOffsets>();
-        public static Dictionary<int, _sDirectoryOffsets> ChunkHash2 = new Dictionary<int, _sDirectoryOffsets>();
+        private Dictionary<uint, _sDirectoryList> folderHashDict;
+        private Dictionary<int, _sDirectoryOffsets> chunkHash1 = new Dictionary<int, _sDirectoryOffsets>();
+        private Dictionary<int, _sDirectoryOffsets> chunkHash2 = new Dictionary<int, _sDirectoryOffsets>();
 
-        private static long SubFileInformationStart;
-        private static long SubFileInformationStart2;
+        private long subFileInformationStart;
+        private long subFileInformationStart2;
 
-        public static void Open()
+        public ARC(string fileName)
         {
-            if (!File.Exists(FilePath))
-            {
-                using (OpenFileDialog d = new OpenFileDialog())
-                {
-                    d.Title = "Select your data.arc file";
-                    d.FileName = "data.arc";
-                    d.Filter = "Smash Ultimate ARC (*.arc)|*.arc";
+            FilePath = fileName;
+            Open();
+        }
 
-                    if (d.ShowDialog() == DialogResult.OK)
-                    {
-                        FilePath = d.FileName;
-                    }
-                    else
-                    {
-                        return;
-                    }
-                }
-            }
-
+        private void Open()
+        {
             Stopwatch stopwatch = Stopwatch.StartNew();
 
-            MemoryStream DecompTables = new MemoryStream();
-            byte[] DecompTableData;
-            using (BinaryReader R = new BinaryReader(new FileStream(FilePath, FileMode.Open)))
+            MemoryStream decompTables = new MemoryStream();
+            byte[] decompTableData;
+            using (BinaryReader r = new BinaryReader(new FileStream(FilePath, FileMode.Open)))
             {
-                Header = ByteToType<_sArcHeader>(R);
+                header = ByteToType<_sArcHeader>(r);
 
                 // Reading First Section
-                Debug.WriteLine(R.BaseStream.Position.ToString("X"));
+                Debug.WriteLine(r.BaseStream.Position.ToString("X"));
                 //compressed table
                 //FileStream DecompTables = new FileStream("Tables", FileMode.Create);
-                R.BaseStream.Seek(Header.NodeSectionOffset, SeekOrigin.Begin);
-                using (BinaryWriter writer = new BinaryWriter(DecompTables))
+                r.BaseStream.Seek(header.NodeSectionOffset, SeekOrigin.Begin);
+                using (BinaryWriter writer = new BinaryWriter(decompTables))
                 {
-                    if (R.ReadUInt32() == 0x10)
+                    if (r.ReadUInt32() == 0x10)
                     {
                         // grab tables
-                        R.ReadInt32();
-                        int CompSize = R.ReadInt32();
-                        long NextTable = R.ReadInt32() + R.BaseStream.Position;
-                        writer.Write(Decompress(R.ReadBytes(CompSize)));
-                        R.BaseStream.Position = NextTable;
+                        r.ReadInt32();
+                        int compSize = r.ReadInt32();
+                        long nextTable = r.ReadInt32() + r.BaseStream.Position;
+                        writer.Write(Decompress(r.ReadBytes(compSize)));
+                        r.BaseStream.Position = nextTable;
                     }
                 }
-                DecompTableData = DecompTables.ToArray();
-                if (DecompTableData.Length == 0)
+                decompTableData = decompTables.ToArray();
+                if (decompTableData.Length == 0)
                 {
-                    R.BaseStream.Seek(Header.NodeSectionOffset, SeekOrigin.Begin);
-                    DecompTableData = (R.ReadBytes((int)(R.BaseStream.Length - R.BaseStream.Position)));
+                    r.BaseStream.Seek(header.NodeSectionOffset, SeekOrigin.Begin);
+                    decompTableData = (r.ReadBytes((int)(r.BaseStream.Length - r.BaseStream.Position)));
                 }
             }
 
 
             // hacky hacky paddy wacky
-            if (Header.NodeSectionOffset == 0x0375D6E118)
+            if (header.NodeSectionOffset == 0x0375D6E118)
             {
-                ArcVersion = 3;
-                ReadV2Arc(DecompTableData);
+                arcVersion = 3;
+                ReadV2Arc(decompTableData);
             }
             else
-            if (Header.FileSectionOffset >= 0x8824AF68)
+            if (header.FileSectionOffset >= 0x8824AF68)
             {
-                ArcVersion = 2;
-                ReadV2Arc(DecompTableData);
+                arcVersion = 2;
+                ReadV2Arc(decompTableData);
             }
             else
-                ReadV1Arc(DecompTableData);
+                ReadV1Arc(decompTableData);
 
             stopwatch.Stop();
             Debug.WriteLine($"Initiating Arc: {stopwatch.ElapsedMilliseconds}");
         }
 
-
-        private static void ReadV1Arc(byte[] TableData)
+        private void ReadV1Arc(byte[] tableData)
         {
-            using (BinaryReader R = new BinaryReader(new MemoryStream(TableData)))
+            using (BinaryReader reader = new BinaryReader(new MemoryStream(tableData)))
             {
-                R.BaseStream.Position = 0;
-                _sNodeHeader NodeHeader = ByteToType<_sNodeHeader>(R);
+                reader.BaseStream.Position = 0;
+                _sNodeHeader nodeHeader = ByteToType<_sNodeHeader>(reader);
 
-                R.BaseStream.Seek(0x68, SeekOrigin.Begin);
+                reader.BaseStream.Seek(0x68, SeekOrigin.Begin);
 
                 // Hash Table
-                R.BaseStream.Seek(0x8 * NodeHeader.Part1Count, SeekOrigin.Current);
+                reader.BaseStream.Seek(0x8 * nodeHeader.Part1Count, SeekOrigin.Current);
 
                 // Hash Table 2
-                StreamNameToHash = ArcArrayReading.ReadSStreamNamesToHashes(R, NodeHeader.Part1Count);
+                streamNameToHash = ArcArrayReading.ReadSStreamNamesToHashes(reader, nodeHeader.Part1Count);
 
                 // Hash Table 3
-                StreamIndexToFile = ArcArrayReading.ReadSStreamIndicesToFiles(R, NodeHeader.Part2Count);
+                streamIndexToFile = ArcArrayReading.ReadSStreamIndicesToFiles(reader, nodeHeader.Part2Count);
 
                 // stream offsets
-                StreamOffsets = ArcArrayReading.ReadSStreamOffsets(R, NodeHeader.MusicFileCount);
+                streamOffsets = ArcArrayReading.ReadSStreamOffsets(reader, nodeHeader.MusicFileCount);
 
                 // Another Hash Table
-                Debug.WriteLine("RegionalHashList " + R.BaseStream.Position.ToString("X"));
-                R.BaseStream.Seek(0xC * 0xE, SeekOrigin.Current);
+                Debug.WriteLine("RegionalHashList " + reader.BaseStream.Position.ToString("X"));
+                reader.BaseStream.Seek(0xC * 0xE, SeekOrigin.Current);
 
                 //folders
 
-                Debug.WriteLine("FodlerHashes " + R.BaseStream.Position.ToString("X"));
-                DirectoryLists = ArcArrayReading.ReadSDirectoryLists(R, NodeHeader.FolderCount);
+                Debug.WriteLine("FodlerHashes " + reader.BaseStream.Position.ToString("X"));
+                directoryLists = ArcArrayReading.ReadSDirectoryLists(reader, nodeHeader.FolderCount);
 
                 //file offsets
 
-                Debug.WriteLine("fileoffsets " + R.BaseStream.Position.ToString("X"));
-                DirectoryOffsets_1 = ArcArrayReading.ReadDirectoryOffsets(R, NodeHeader.FileCount1);
-                DirectoryOffsets_2 = ArcArrayReading.ReadDirectoryOffsets(R, NodeHeader.FileCount2);
+                Debug.WriteLine("fileoffsets " + reader.BaseStream.Position.ToString("X"));
+                directoryOffsets1 = ArcArrayReading.ReadDirectoryOffsets(reader, nodeHeader.FileCount1);
+                directoryOffsets2 = ArcArrayReading.ReadDirectoryOffsets(reader, nodeHeader.FileCount2);
 
-                Debug.WriteLine("subfileoffset " + R.BaseStream.Position.ToString("X"));
-                HashFolderCounts = ArcArrayReading.ReadSFolderHashIndices(R, NodeHeader.HashFolderCount);
+                Debug.WriteLine("subfileoffset " + reader.BaseStream.Position.ToString("X"));
+                hashFolderCounts = ArcArrayReading.ReadSFolderHashIndices(reader, nodeHeader.HashFolderCount);
 
-                Debug.WriteLine("subfileoffset " + R.BaseStream.Position.ToString("X"));
-                FileInformation = ReadArray<_sFileInformation>(R, NodeHeader.FileInformationCount);
+                Debug.WriteLine("subfileoffset " + reader.BaseStream.Position.ToString("X"));
+                fileInformation = ReadArray<_sFileInformation>(reader, nodeHeader.FileInformationCount);
 
-                Debug.WriteLine("subfileoffset " + R.BaseStream.Position.ToString("X"));
-                SubFileInformationStart = R.BaseStream.Position;
-                SubFileInformation_1 = ArcArrayReading.ReadSubFileInfos(R, NodeHeader.SubFileCount);
-                SubFileInformationStart2 = R.BaseStream.Position;
-                SubFileInformation_2 = ArcArrayReading.ReadSubFileInfos(R, NodeHeader.SubFileCount2);
+                Debug.WriteLine("subfileoffset " + reader.BaseStream.Position.ToString("X"));
+                subFileInformationStart = reader.BaseStream.Position;
+                subFileInformation1 = ArcArrayReading.ReadSubFileInfos(reader, nodeHeader.SubFileCount);
+                subFileInformationStart2 = reader.BaseStream.Position;
+                subFileInformation2 = ArcArrayReading.ReadSubFileInfos(reader, nodeHeader.SubFileCount2);
 
-                _sHashInt[] HashInts = ArcArrayReading.ReadHashInts(R, NodeHeader.FolderCount);
+                _sHashInt[] hashInts = ArcArrayReading.ReadHashInts(reader, nodeHeader.FolderCount);
 
                 // okay some more file information
-                uint FileHashCount = R.ReadUInt32();
-                uint UnknownTableCount = R.ReadUInt32();
+                uint fileHashCount = reader.ReadUInt32();
+                uint unknownTableCount = reader.ReadUInt32();
 
-                _sExtraFITable[] Extra1 = ReadArray<_sExtraFITable>(R, UnknownTableCount);
-                _sExtraFITable2[] Extra2 = ReadArray<_sExtraFITable2>(R, FileHashCount);
+                // TODO: Add methods to ArcArrayReading.cs
+                _sExtraFITable[] extra1 = ReadArray<_sExtraFITable>(reader, unknownTableCount);
+                _sExtraFITable2[] extra2 = ReadArray<_sExtraFITable2>(reader, fileHashCount);
 
-                R.BaseStream.Position += 8 * NodeHeader.FileInformationCount;
+                reader.BaseStream.Position += 8 * nodeHeader.FileInformationCount;
 
-                FolderHashDict = new Dictionary<uint, _sDirectoryList>();
-                foreach (_sDirectoryList fh in DirectoryLists)
+                folderHashDict = new Dictionary<uint, _sDirectoryList>();
+                foreach (_sDirectoryList fh in directoryLists)
                 {
-                    FolderHashDict.Add(fh.HashID, fh);
+                    folderHashDict.Add(fh.HashID, fh);
                 }
 
-                foreach (_sDirectoryOffsets chunk in DirectoryOffsets_1)
+                foreach (_sDirectoryOffsets chunk in directoryOffsets1)
                 {
                     for (int i = 0; i < chunk.SubDataCount; i++)
-                        if (!ChunkHash1.ContainsKey((int)chunk.SubDataStartIndex + i))
-                            ChunkHash1.Add((int)chunk.SubDataStartIndex + i, chunk);
+                        if (!chunkHash1.ContainsKey((int)chunk.SubDataStartIndex + i))
+                            chunkHash1.Add((int)chunk.SubDataStartIndex + i, chunk);
                 }
-                foreach (_sDirectoryOffsets chunk in DirectoryOffsets_2)
+                foreach (_sDirectoryOffsets chunk in directoryOffsets2)
                 {
                     for (int i = 0; i < chunk.SubDataCount; i++)
-                        if (!ChunkHash2.ContainsKey((int)chunk.SubDataStartIndex + i))
-                            ChunkHash2.Add((int)chunk.SubDataStartIndex + i, chunk);
+                        if (!chunkHash2.ContainsKey((int)chunk.SubDataStartIndex + i))
+                            chunkHash2.Add((int)chunk.SubDataStartIndex + i, chunk);
                 }
             }
         }
 
-        private static void ReadV2Arc(byte[] TableData)
+        private void ReadV2Arc(byte[] tableData)
         {
-            using (BinaryReader R = new BinaryReader(new MemoryStream(TableData)))
+            using (BinaryReader reader = new BinaryReader(new MemoryStream(tableData)))
             {
-                R.BaseStream.Position = 0;
-                _sNodeHeaderv2 NodeHeader = ByteToType<_sNodeHeaderv2>(R);
+                reader.BaseStream.Position = 0;
+                _sNodeHeaderv2 nodeHeader = ByteToType<_sNodeHeaderv2>(reader);
                 //PrintStruct<_sNodeHeader>(NodeHeader);
 
-                if (ArcVersion == 3)
-                    R.BaseStream.Seek(0x58, SeekOrigin.Begin);
+                if (arcVersion == 3)
+                    reader.BaseStream.Seek(0x58, SeekOrigin.Begin);
                 else
-                    R.BaseStream.Seek(0x3C, SeekOrigin.Begin);
+                    reader.BaseStream.Seek(0x3C, SeekOrigin.Begin);
 
                 // Unknown?? maybe something with languages
-                R.BaseStream.Seek(0xE * 12, SeekOrigin.Current);
+                reader.BaseStream.Seek(0xE * 12, SeekOrigin.Current);
 
                 // Another structure
-                _sNodeHeaderv2_2 NodeHeader2 = ByteToType<_sNodeHeaderv2_2>(R);
+                _sNodeHeaderv2_2 nodeHeader2 = ByteToType<_sNodeHeaderv2_2>(reader);
 
                 // Hash Table
-                Console.WriteLine("Hash table 1 " + R.BaseStream.Position.ToString("X"));
-                R.BaseStream.Seek(0x8 * NodeHeader2.Part1Count, SeekOrigin.Current);
+                Console.WriteLine("Hash table 1 " + reader.BaseStream.Position.ToString("X"));
+                reader.BaseStream.Seek(0x8 * nodeHeader2.Part1Count, SeekOrigin.Current);
 
                 // Hash Table 2
-                Console.WriteLine("StreamToHash table 2 " + R.BaseStream.Position.ToString("X"));
-                StreamNameToHash = ArcArrayReading.ReadSStreamNamesToHashes(R, NodeHeader2.Part1Count);
+                Console.WriteLine("StreamToHash table 2 " + reader.BaseStream.Position.ToString("X"));
+                streamNameToHash = ArcArrayReading.ReadSStreamNamesToHashes(reader, nodeHeader2.Part1Count);
 
                 // Hash Table 3
-                Console.WriteLine("Hash table 3 " + R.BaseStream.Position.ToString("X"));
-                StreamIndexToFile = ArcArrayReading.ReadSStreamIndicesToFiles(R, NodeHeader2.Part2Count);
+                Console.WriteLine("Hash table 3 " + reader.BaseStream.Position.ToString("X"));
+                streamIndexToFile = ArcArrayReading.ReadSStreamIndicesToFiles(reader, nodeHeader2.Part2Count);
 
                 // stream offsets
-                Console.WriteLine("Hash table 4 " + R.BaseStream.Position.ToString("X"));
-                StreamOffsets = ArcArrayReading.ReadSStreamOffsets(R, NodeHeader2.Part3Size);
+                Console.WriteLine("Hash table 4 " + reader.BaseStream.Position.ToString("X"));
+                streamOffsets = ArcArrayReading.ReadSStreamOffsets(reader, nodeHeader2.Part3Size);
 
-                Console.WriteLine("Hash table 5 " + R.BaseStream.Position.ToString("X"));
-                int UnkCount1 = R.ReadInt32();
-                int UnkCount2 = R.ReadInt32();
-                R.BaseStream.Seek(0x8 * UnkCount2, SeekOrigin.Current);
-                R.BaseStream.Seek(0x8 * UnkCount1, SeekOrigin.Current);
+                Console.WriteLine("Hash table 5 " + reader.BaseStream.Position.ToString("X"));
+                int unkCount1 = reader.ReadInt32();
+                int unkCount2 = reader.ReadInt32();
+                reader.BaseStream.Seek(0x8 * unkCount2, SeekOrigin.Current);
+                reader.BaseStream.Seek(0x8 * unkCount1, SeekOrigin.Current);
 
-                Debug.WriteLine("FilePathInfo " + R.BaseStream.Position.ToString("X"));
-                FileInformationPath = ArcArrayReading.ReadSFileInformationPaths(R, NodeHeader.UnkCount);
-
-                // Start of first node header section
-                Debug.WriteLine("SomeIndicesForFileInformation " + R.BaseStream.Position.ToString("X"));
-                FileInformationIndex = ArcArrayReading.ReadSFileInformationIndices(R, NodeHeader.UnkOffsetSizeCount);
+                Debug.WriteLine("FilePathInfo " + reader.BaseStream.Position.ToString("X"));
+                fileInformationPath = ArcArrayReading.ReadSFileInformationPaths(reader, nodeHeader.UnkCount);
 
                 // Start of first node header section
-                Debug.WriteLine("FolderHashes " + R.BaseStream.Position.ToString("X"));
-                R.BaseStream.Seek(0x8 * NodeHeader.FolderCount, SeekOrigin.Current);
+                Debug.WriteLine("SomeIndicesForFileInformation " + reader.BaseStream.Position.ToString("X"));
+                fileInformationIndex = ArcArrayReading.ReadSFileInformationIndices(reader, nodeHeader.UnkOffsetSizeCount);
+
+                // Start of first node header section
+                Debug.WriteLine("FolderHashes " + reader.BaseStream.Position.ToString("X"));
+                reader.BaseStream.Seek(0x8 * nodeHeader.FolderCount, SeekOrigin.Current);
 
                 //folders
 
-                Debug.WriteLine("FolderHashes " + R.BaseStream.Position.ToString("X"));
-                DirectoryLists = ArcArrayReading.ReadSDirectoryLists(R, NodeHeader.FolderCount);
+                Debug.WriteLine("FolderHashes " + reader.BaseStream.Position.ToString("X"));
+                directoryLists = ArcArrayReading.ReadSDirectoryLists(reader, nodeHeader.FolderCount);
 
                 //file offsets
 
-                Debug.WriteLine("fileoffsets " + R.BaseStream.Position.ToString("X"));
-                DirectoryOffsets_1 = ArcArrayReading.ReadDirectoryOffsets(R, NodeHeader.FileCount1);
-                DirectoryOffsets_2 = ArcArrayReading.ReadDirectoryOffsets(R, NodeHeader.FileCount2);
+                Debug.WriteLine("fileoffsets " + reader.BaseStream.Position.ToString("X"));
+                directoryOffsets1 = ArcArrayReading.ReadDirectoryOffsets(reader, nodeHeader.FileCount1);
+                directoryOffsets2 = ArcArrayReading.ReadDirectoryOffsets(reader, nodeHeader.FileCount2);
 
-                Debug.WriteLine("hashfolderoffset " + R.BaseStream.Position.ToString("X"));
-                HashFolderCounts = ArcArrayReading.ReadSFolderHashIndices(R, NodeHeader.HashFolderCount);
+                Debug.WriteLine("hashfolderoffset " + reader.BaseStream.Position.ToString("X"));
+                hashFolderCounts = ArcArrayReading.ReadSFolderHashIndices(reader, nodeHeader.HashFolderCount);
 
-                Debug.WriteLine("fileinformationoffset " + R.BaseStream.Position.ToString("X"));
-                FileInformationV2 = ArcArrayReading.ReadSFileInformationV2(R, NodeHeader.FileInformationCount + NodeHeader.SubFileCount2);
+                Debug.WriteLine("fileinformationoffset " + reader.BaseStream.Position.ToString("X"));
+                fileInformationV2 = ArcArrayReading.ReadSFileInformationV2(reader, nodeHeader.FileInformationCount + nodeHeader.SubFileCount2);
 
-                Debug.WriteLine("sub index table " + R.BaseStream.Position.ToString("X"));
-                FileInformationSubIndex = ArcArrayReading.ReadSFileInformationSubIndices(R, NodeHeader.LastTableCount + NodeHeader.SubFileCount2);
+                Debug.WriteLine("sub index table " + reader.BaseStream.Position.ToString("X"));
+                fileInformationSubIndex = ArcArrayReading.ReadSFileInformationSubIndices(reader, nodeHeader.LastTableCount + nodeHeader.SubFileCount2);
 
-                Debug.WriteLine("subfileoffset " + R.BaseStream.Position.ToString("X"));
-                SubFileInformationStart = R.BaseStream.Position;
-                SubFileInformation_1 = ArcArrayReading.ReadSubFileInfos(R, NodeHeader.SubFileCount);
+                Debug.WriteLine("subfileoffset " + reader.BaseStream.Position.ToString("X"));
+                subFileInformationStart = reader.BaseStream.Position;
+                subFileInformation1 = ArcArrayReading.ReadSubFileInfos(reader, nodeHeader.SubFileCount);
 
-                SubFileInformationStart2 = R.BaseStream.Position;
-                SubFileInformation_2 = ArcArrayReading.ReadSubFileInfos(R, NodeHeader.SubFileCount2);
+                subFileInformationStart2 = reader.BaseStream.Position;
+                subFileInformation2 = ArcArrayReading.ReadSubFileInfos(reader, nodeHeader.SubFileCount2);
 
                 int max = 0;
-                foreach (var dir in FileInformationSubIndex)
+                foreach (var dir in fileInformationSubIndex)
                 {
                     max = Math.Max(max, (int)dir.SomeIndex1);
                 }
-                Console.WriteLine($"Directory index {max.ToString("X")} {DirectoryLists.Length.ToString("X")} {(DirectoryOffsets_1.Length + DirectoryOffsets_2.Length).ToString("X")}");
+                Console.WriteLine($"Directory index {max.ToString("X")} {directoryLists.Length.ToString("X")} {(directoryOffsets1.Length + directoryOffsets2.Length).ToString("X")}");
 
 
-                FolderHashDict = new Dictionary<uint, _sDirectoryList>();
-                foreach (_sDirectoryList fh in DirectoryLists)
+                folderHashDict = new Dictionary<uint, _sDirectoryList>();
+                foreach (_sDirectoryList fh in directoryLists)
                 {
-                    FolderHashDict.Add(fh.HashID, fh);
+                    folderHashDict.Add(fh.HashID, fh);
                 }
 
-                foreach (_sDirectoryOffsets chunk in DirectoryOffsets_1)
+                foreach (_sDirectoryOffsets chunk in directoryOffsets1)
                 {
                     for (int i = 0; i < chunk.SubDataCount; i++)
                     {
-                        if (!ChunkHash1.ContainsKey((int)chunk.SubDataStartIndex + i))
-                            ChunkHash1.Add((int)chunk.SubDataStartIndex + i, chunk);
+                        if (!chunkHash1.ContainsKey((int)chunk.SubDataStartIndex + i))
+                            chunkHash1.Add((int)chunk.SubDataStartIndex + i, chunk);
                     }
                 }
-                foreach (_sDirectoryOffsets chunk in DirectoryOffsets_2)
+                foreach (_sDirectoryOffsets chunk in directoryOffsets2)
                 {
                     for (int i = 0; i < chunk.SubDataCount; i++)
                     {
-                        if (!ChunkHash2.ContainsKey((int)chunk.SubDataStartIndex + i))
-                            ChunkHash2.Add((int)chunk.SubDataStartIndex + i, chunk);
+                        if (!chunkHash2.ContainsKey((int)chunk.SubDataStartIndex + i))
+                            chunkHash2.Add((int)chunk.SubDataStartIndex + i, chunk);
                     }
                 }
             }
         }
 
-        public static List<FileOffsetGroup> GetStreamFiles()
+        public List<FileOffsetGroup> GetStreamFiles()
         {
-            return GetStreamFilesV2();
-        }
+            var streamfiles = new List<FileOffsetGroup>(streamNameToHash.Length);
 
-        private static List<FileOffsetGroup> GetStreamFilesV2()
-        {
-            var streamfiles = new List<FileOffsetGroup>(StreamNameToHash.Length);
-
-            foreach (var streamfile in StreamNameToHash)
+            foreach (var streamfile in streamNameToHash)
             {
                 FileOffsetGroup group = new FileOffsetGroup();
                 group.FileName = GetName(streamfile.Hash);
@@ -352,8 +333,8 @@ namespace CrossArc
                         size = 0x5;
                     for (int i = 0; i < size; i++)
                     {
-                        var streamindex = StreamIndexToFile[(streamfile.NameIndex >> 8) + i].FileIndex;
-                        var offset = StreamOffsets[streamindex];
+                        var streamindex = streamIndexToFile[(streamfile.NameIndex >> 8) + i].FileIndex;
+                        var offset = streamOffsets[streamindex];
                         group.ArcOffset[i] = offset.Offset;
                         group.CompSize[i] = offset.Size;
                         group.DecompSize[i] = offset.Size;
@@ -362,8 +343,8 @@ namespace CrossArc
                 }
                 else
                 {
-                    var streamindex = StreamIndexToFile[streamfile.NameIndex >> 8].FileIndex;
-                    var offset = StreamOffsets[streamindex];
+                    var streamindex = streamIndexToFile[streamfile.NameIndex >> 8].FileIndex;
+                    var offset = streamOffsets[streamindex];
                     group.ArcOffset = new long[] { offset.Offset };
                     group.CompSize = new long[] { offset.Size };
                     group.DecompSize = new long[] { offset.Size };
@@ -376,24 +357,23 @@ namespace CrossArc
         }
 
 
-        public static List<FileOffsetGroup> GetFiles()
+        public List<FileOffsetGroup> GetFiles()
         {
-            Console.WriteLine($"Version: {ArcVersion}, V2: {(ArcVersion == 2)}");
-            if (ArcVersion == 3)
+            Console.WriteLine($"Version: {arcVersion}, V2: {(arcVersion == 2)}");
+            if (arcVersion == 3)
                 return GetFilesV2();
-            else if (ArcVersion == 2)
+            else if (arcVersion == 2)
                 return GetFilesV2();
             else
                 return GetFilesV1();
         }
 
-
-        public static List<FileOffsetGroup> GetFilesV1()
+        private List<FileOffsetGroup> GetFilesV1()
         {
-            List<FileOffsetGroup> files = new List<FileOffsetGroup>(FileInformation.Length);
-            foreach (var item in FileInformation)
+            List<FileOffsetGroup> files = new List<FileOffsetGroup>(fileInformation.Length);
+            foreach (var item in fileInformation)
             {
-                var directory = DirectoryLists[item.DirectoryIndex >> 8];
+                var directory = directoryLists[item.DirectoryIndex >> 8];
                 var offsetGroup = GetFileInformation(item);
                 if ((item.FileTableFlag >> 8) > 0)
                 {
@@ -424,34 +404,40 @@ namespace CrossArc
             return extension;
         }
 
-        public static List<FileOffsetGroup> GetFilesV2()
+        private List<FileOffsetGroup> GetFilesV2()
         {
-            List<FileOffsetGroup> files = new List<FileOffsetGroup>(FileInformationV2.Length);
-            Console.WriteLine("Files " + FileInformationV2.Length);
+            List<FileOffsetGroup> files = new List<FileOffsetGroup>(fileInformationV2.Length);
+            Console.WriteLine("Files " + fileInformationV2.Length);
 
-            foreach (var item in FileInformationV2)
+            foreach (var item in fileInformationV2)
             {
-                var pathInfo = FileInformationPath[item.HashIndex];
-                var offsetGroup = GetFileInformation(item);
-                if ((item.Flags & 0xF000) == 0x8000)
-                {
-                    for (int i = 1; i < 0xE; i++)
-                    {
-                        var offsetGroup2 = GetFileInformation(item, i);
-                        offsetGroup = ResizeOffsetGroupArrays(offsetGroup, offsetGroup2, i);
-                    }
-                }
-
-                offsetGroup.FileNameHash = pathInfo.Hash2;
-                offsetGroup.PathHash = pathInfo.Parent;
-
-                string extension = GetExtensionV2(pathInfo);
-
-                offsetGroup.FileName = GetName(pathInfo.Hash2, extension);
-                offsetGroup.Path = GetName(pathInfo.Parent);
+                var offsetGroup = CreateFileOffsetGroup(item);
                 files.Add(offsetGroup);
             }
             return files;
+        }
+
+        private FileOffsetGroup CreateFileOffsetGroup(_sFileInformationV2 item)
+        {
+            var offsetGroup = GetFileInformation(item);
+            if ((item.Flags & 0xF000) == 0x8000)
+            {
+                for (int i = 1; i < 0xE; i++)
+                {
+                    var offsetGroup2 = GetFileInformation(item, i);
+                    offsetGroup = ResizeOffsetGroupArrays(offsetGroup, offsetGroup2, i);
+                }
+            }
+
+            var pathInfo = fileInformationPath[item.HashIndex];
+            offsetGroup.FileNameHash = pathInfo.Hash2;
+            offsetGroup.PathHash = pathInfo.Parent;
+
+            string extension = GetExtensionV2(pathInfo);
+
+            offsetGroup.FileName = GetName(pathInfo.Hash2, extension);
+            offsetGroup.Path = GetName(pathInfo.Parent);
+            return offsetGroup;
         }
 
         private static string GetExtensionV2(_sFileInformationPath pathInfo)
@@ -481,155 +467,155 @@ namespace CrossArc
             return offsetGroup;
         }
 
-        private static FileOffsetGroup GetFileInformation(_sFileInformation FileInfo, int RegionalIndex = 0)
+        private FileOffsetGroup GetFileInformation(_sFileInformation fileInfo, int regionalIndex = 0)
         {
-            return GetFileInformation(FileInfo.SubFile_Index, (FileInfo.FileTableFlag >> 8), DirectoryLists[FileInfo.DirectoryIndex >> 8].DirOffsetIndex >> 8, RegionalIndex);
+            return GetFileInformation(fileInfo.SubFile_Index, (fileInfo.FileTableFlag >> 8), directoryLists[fileInfo.DirectoryIndex >> 8].DirOffsetIndex >> 8, regionalIndex);
         }
 
-        private static FileOffsetGroup GetFileInformation(_sFileInformationV2 FileInfo, int RegionalIndex = 0)
+        private FileOffsetGroup GetFileInformation(_sFileInformationV2 fileInfo, int regionalIndex = 0)
         {
-            bool Regional = FileInfo.Flags == 0x8010;
-            var path = FileInformationPath[FileInfo.HashIndex];
-            var dirinfo = FileInformationIndex[FileInfo.HashIndex2 + (Regional ? RegionalIndex + 1 : 0)];
-            var subinfo = FileInformationSubIndex[FileInfo.SubFile_Index + (Regional ? RegionalIndex + 1 : 0)];
-            return GetFileInformation(subinfo.SomeIndex2, 0, subinfo.SomeIndex1, RegionalIndex);
+            bool regional = fileInfo.Flags == 0x8010;
+            var path = fileInformationPath[fileInfo.HashIndex];
+            var dirinfo = fileInformationIndex[fileInfo.HashIndex2 + (regional ? regionalIndex + 1 : 0)];
+            var subinfo = fileInformationSubIndex[fileInfo.SubFile_Index + (regional ? regionalIndex + 1 : 0)];
+            return GetFileInformation(subinfo.SomeIndex2, 0, subinfo.SomeIndex1, regionalIndex);
         }
 
-        private static FileOffsetGroup GetFileInformation(uint SubFile_Index, uint RegionalOffset, uint DirectoryIndex, int RegionalIndex = 0)
+        private FileOffsetGroup GetFileInformation(uint subFileIndex, uint regionalOffset, uint directoryIndex, int regionalIndex = 0)
         {
             FileOffsetGroup g = new FileOffsetGroup();
 
             // Get File Data
 
-            _SubFileInfo FileOffset;
-            if (SubFile_Index < SubFileInformation_1.Length)
-                FileOffset = SubFileInformation_1[SubFile_Index];
+            _SubFileInfo fileOffset;
+            if (subFileIndex < subFileInformation1.Length)
+                fileOffset = subFileInformation1[subFileIndex];
             else
-                FileOffset = SubFileInformation_2[SubFile_Index - SubFileInformation_1.Length];
+                fileOffset = subFileInformation2[subFileIndex - subFileInformation1.Length];
 
-            _sDirectoryOffsets DirectoryOffset;
-            if (DirectoryIndex < DirectoryOffsets_1.Length)
-                DirectoryOffset = DirectoryOffsets_1[DirectoryIndex];
+            _sDirectoryOffsets directoryOffset;
+            if (directoryIndex < directoryOffsets1.Length)
+                directoryOffset = directoryOffsets1[directoryIndex];
             else
-                DirectoryOffset = DirectoryOffsets_2[DirectoryIndex - DirectoryOffsets_1.Length];
-            var DirectoryOffset2 = DirectoryOffset;
+                directoryOffset = directoryOffsets2[directoryIndex - directoryOffsets1.Length];
+            var directoryOffset2 = directoryOffset;
 
-            if (RegionalOffset > 0)
+            if (regionalOffset > 0)
             {
-                FileOffset = SubFileInformation_1[RegionalOffset + RegionalIndex];
-                DirectoryIndex = (uint)(DirectoryIndex + 1 + RegionalIndex);
-                if (DirectoryIndex < DirectoryOffsets_1.Length)
-                    DirectoryOffset = DirectoryOffsets_1[DirectoryIndex];
+                fileOffset = subFileInformation1[regionalOffset + regionalIndex];
+                directoryIndex = (uint)(directoryIndex + 1 + regionalIndex);
+                if (directoryIndex < directoryOffsets1.Length)
+                    directoryOffset = directoryOffsets1[directoryIndex];
                 else
-                    DirectoryOffset = DirectoryOffsets_2[DirectoryIndex - DirectoryOffsets_1.Length];
-                DirectoryOffset2 = DirectoryOffset;
+                    directoryOffset = directoryOffsets2[directoryIndex - directoryOffsets1.Length];
+                directoryOffset2 = directoryOffset;
             }
             else
-            if ((DirectoryOffset.ResourceIndex & 0xFFFFFF) != 0xFFFFFF)
+            if ((directoryOffset.ResourceIndex & 0xFFFFFF) != 0xFFFFFF)
             {
-                if (DirectoryOffset.ResourceIndex < DirectoryOffsets_1.Length)
-                    DirectoryOffset2 = DirectoryOffsets_1[((DirectoryOffset.ResourceIndex) & 0xFFFFFF)];
+                if (directoryOffset.ResourceIndex < directoryOffsets1.Length)
+                    directoryOffset2 = directoryOffsets1[((directoryOffset.ResourceIndex) & 0xFFFFFF)];
                 else
-                    DirectoryOffset2 = DirectoryOffsets_2[((DirectoryOffset.ResourceIndex - DirectoryOffsets_1.Length) & 0xFFFFFF)];
+                    directoryOffset2 = directoryOffsets2[((directoryOffset.ResourceIndex - directoryOffsets1.Length) & 0xFFFFFF)];
 
             }
 
             // Parse Flags
-            int flag = ((int)FileOffset.Flags >> 24);
-            bool Compressed = (flag & 0x03) == 0x03;
-            bool External = (flag & 0x08) == 0x08;
-            int ExternalOffset = (int)FileOffset.Flags & 0xFFFFFF;
+            int flag = ((int)fileOffset.Flags >> 24);
+            bool compressed = (flag & 0x03) == 0x03;
+            bool external = (flag & 0x08) == 0x08;
+            int externalOffset = (int)fileOffset.Flags & 0xFFFFFF;
 
-            if ((ArcVersion >= 2))
+            if ((arcVersion >= 2))
             {
                 // why did they do this
-                flag = ((int)FileOffset.Flags & 0xFF);
-                Compressed = (flag & 0x03) == 0x03;
-                External = (flag & 0x08) == 0x08;
-                ExternalOffset = (int)FileOffset.Flags >> 8;
+                flag = ((int)fileOffset.Flags & 0xFF);
+                compressed = (flag & 0x03) == 0x03;
+                external = (flag & 0x08) == 0x08;
+                externalOffset = (int)fileOffset.Flags >> 8;
             }
 
-            if (ExternalOffset > 0 && !External)
+            if (externalOffset > 0 && !external)
             {
-                if (ArcVersion >= 2)
+                if (arcVersion >= 2)
                 {
-                    return GetFileInformation(FileInformationV2[ExternalOffset]);
+                    return GetFileInformation(fileInformationV2[externalOffset]);
                 }
                 else
                 {
-                    return GetFileInformation(FileInformation[ExternalOffset]);
+                    return GetFileInformation(fileInformation[externalOffset]);
                 }
             }
 
-            if (External)
+            if (external)
             {
                 //hack
-                DirectoryOffset2 = ChunkHash2[ExternalOffset];
-                FileOffset = SubFileInformation_2[ExternalOffset];
+                directoryOffset2 = chunkHash2[externalOffset];
+                fileOffset = subFileInformation2[externalOffset];
 
-                g.ArcOffset = new long[] { (Header.FileSectionOffset + DirectoryOffset2.Offset + (FileOffset.Offset << 2)) };
-                g.Offset = new long[] { FileOffset.Offset };
-                g.CompSize = new long[] { FileOffset.CompSize };
-                g.DecompSize = new long[] { FileOffset.DecompSize };
-                g.Flags = new uint[] { FileOffset.Flags };
-                g.SubFileInformationOffset = SubFileInformationStart2 + ExternalOffset * 16;
+                g.ArcOffset = new long[] { (header.FileSectionOffset + directoryOffset2.Offset + (fileOffset.Offset << 2)) };
+                g.Offset = new long[] { fileOffset.Offset };
+                g.CompSize = new long[] { fileOffset.CompSize };
+                g.DecompSize = new long[] { fileOffset.DecompSize };
+                g.Flags = new uint[] { fileOffset.Flags };
+                g.SubFileInformationOffset = subFileInformationStart2 + externalOffset * 16;
             }
             else
             {
-                g.ArcOffset = new long[] { (Header.FileSectionOffset + DirectoryOffset.Offset + (FileOffset.Offset << 2)) };
-                g.Offset = new long[] { FileOffset.Offset };
-                g.CompSize = new long[] { FileOffset.CompSize };
-                g.DecompSize = new long[] { FileOffset.DecompSize };
-                g.Flags = new uint[] { FileOffset.Flags };
-                g.SubFileInformationOffset = SubFileInformationStart + SubFile_Index * 16;
+                g.ArcOffset = new long[] { (header.FileSectionOffset + directoryOffset.Offset + (fileOffset.Offset << 2)) };
+                g.Offset = new long[] { fileOffset.Offset };
+                g.CompSize = new long[] { fileOffset.CompSize };
+                g.DecompSize = new long[] { fileOffset.DecompSize };
+                g.Flags = new uint[] { fileOffset.Flags };
+                g.SubFileInformationOffset = subFileInformationStart + subFileIndex * 16;
             }
 
             return g;
         }
 
-        public static string[] GetPaths()
+        public string[] GetPaths()
         {
             List<string> paths = new List<string>();
 
-            foreach (_sFolderHashIndex fhi in HashFolderCounts)
+            foreach (_sFolderHashIndex fhi in hashFolderCounts)
             {
-                paths.Add(GetPathString(FolderHashDict, FolderHashDict[fhi.Hash]));
+                paths.Add(GetPathString(folderHashDict, folderHashDict[fhi.Hash]));
             }
 
             return paths.ToArray();
         }
 
-        public static void CommandFunctions(string FolderToExtract)
+        public void CommandFunctions(string folderToExtract)
         {
-            using (BinaryReader R = new BinaryReader(new FileStream(FilePath, FileMode.Open)))
+            using (BinaryReader r = new BinaryReader(new FileStream(FilePath, FileMode.Open)))
             {
-                if (!FolderToExtract.Equals(""))
+                if (!folderToExtract.Equals(""))
                 {
-                    _sDirectoryList ToExtract;
-                    if (FolderHashDict.TryGetValue(CRC32.Crc32C(FolderToExtract), out ToExtract))
+                    _sDirectoryList toExtract;
+                    if (folderHashDict.TryGetValue(CRC32.Crc32C(folderToExtract), out toExtract))
                     {
-                        Console.WriteLine("Extracting " + GetPathString(FolderHashDict, ToExtract));
-                        ExtractFolder(R, ToExtract);
+                        Console.WriteLine("Extracting " + GetPathString(folderHashDict, toExtract));
+                        ExtractFolder(r, toExtract);
                     }
                     else
                     {
-                        foreach (_sDirectoryList h in DirectoryLists)
+                        foreach (_sDirectoryList h in directoryLists)
                         {
-                            if (GetPathString(FolderHashDict, h).Equals(FolderToExtract))
+                            if (GetPathString(folderHashDict, h).Equals(folderToExtract))
                             {
-                                ExtractFolder(R, h);
+                                ExtractFolder(r, h);
                                 break;
                             }
                         }
-                        Debug.WriteLine("Could no extract " + FolderToExtract);
+                        Debug.WriteLine("Could no extract " + folderToExtract);
                     }
                 }
                 else
                 {
-                    foreach (_sDirectoryList h in DirectoryLists)
+                    foreach (_sDirectoryList h in directoryLists)
                     {
-                        Console.WriteLine("Extracting " + GetPathString(FolderHashDict, h));
-                        ExtractFolder(R, h);
+                        Console.WriteLine("Extracting " + GetPathString(folderHashDict, h));
+                        ExtractFolder(r, h);
                     }
                 }
             }
@@ -637,13 +623,13 @@ namespace CrossArc
         }
 
 
-        public static void HashCheck()
+        public void HashCheck()
         {
-            foreach (_sDirectoryList fh in DirectoryLists)
+            foreach (_sDirectoryList fh in directoryLists)
             {
-                GetPathString(FolderHashDict, fh);
+                GetPathString(folderHashDict, fh);
             }
-            foreach (_sFileInformation fi in FileInformation)
+            foreach (_sFileInformation fi in fileInformation)
             {
                 GetName(fi.Hash2);
                 GetName(fi.Extension);
@@ -667,26 +653,16 @@ namespace CrossArc
 
         }
 
-        public static _sFileInformation[] GetFileInformationFromFolder(_sDirectoryList FolderHash)
+        private void ExtractFolder(BinaryReader stream, _sDirectoryList folderHash)
         {
-            _sFileInformation[] info = new _sFileInformation[(int)FolderHash.FileInformationCount];
-            for (int i = 0; i < FolderHash.FileInformationCount; i++)
+            for (int i = 0; i < folderHash.FileInformationCount; i++)
             {
-                info[i] = (FileInformation[FolderHash.FileInformationStartIndex + i]);
-            }
-            return info;
-        }
+                _sFileInformation info = fileInformation[folderHash.FileInformationStartIndex + i];
 
-        public static void ExtractFolder(BinaryReader Stream, _sDirectoryList FolderHash)
-        {
-            for (int i = 0; i < FolderHash.FileInformationCount; i++)
-            {
-                _sFileInformation info = FileInformation[FolderHash.FileInformationStartIndex + i];
-
-                string FinalPath = GetPathString(FolderHashDict, FolderHash) + "/" + info.Parent.ToString("X");
+                string finalPath = GetPathString(folderHashDict, folderHash) + "/" + info.Parent.ToString("X");
                 //Directory.CreateDirectory(FinalPath);
 
-                _SubFileInfo sub = SubFileInformation_1[info.SubFile_Index];
+                _SubFileInfo sub = subFileInformation1[info.SubFile_Index];
                 //Debug.WriteLine("\tFolder - " + info.Unk4.ToString("X"));
                 //Debug.WriteLine("\t\t" + GetName(info.Hash2) + " " + sub.Flags.ToString("X"));
 
@@ -694,22 +670,22 @@ namespace CrossArc
                 FileOffsetGroup group = GetOffsetFromSubFile(info);
                 //Debug.WriteLine("\t\t\tArcOffset: 0x" + group.ArcOffset.ToString("X") + " Offset: " + group.Offset.ToString("X") + " CompSize: 0x" + group.CompSize.ToString("X") + " DecompSize:" + group.DecompSize.ToString("X") + " Flags: 0x" + group.Flags.ToString("X"));
 
-                ExportFile(FinalPath + "/" + GetName(info.Hash2), Stream, group.ArcOffset[0], group.CompSize[0], group.DecompSize[0]);
+                ExportFile(finalPath + "/" + GetName(info.Hash2), stream, group.ArcOffset[0], group.CompSize[0], group.DecompSize[0]);
             }
         }
 
-        public static void ExportFile(string filepath, BinaryReader R, long Offset, long CompSize, long DecompSize)
+        public static void ExportFile(string filepath, BinaryReader r, long offset, long compSize, long decompSize)
         {
-            File.WriteAllBytes(filepath, GetFileData(R, Offset, CompSize, DecompSize));
+            File.WriteAllBytes(filepath, GetFileData(r, offset, compSize, decompSize));
         }
 
-        private static byte[] GetFileData(BinaryReader R, long Offset, long CompSize, long DecompSize)
+        private static byte[] GetFileData(BinaryReader r, long offset, long compSize, long decompSize)
         {
-            R.BaseStream.Seek(Offset, SeekOrigin.Begin);
+            r.BaseStream.Seek(offset, SeekOrigin.Begin);
 
-            byte[] data = R.ReadBytes((int)CompSize);
+            byte[] data = r.ReadBytes((int)compSize);
 
-            if (CompSize != DecompSize && DecompSize > 0 && CompSize > 0)
+            if (compSize != decompSize && decompSize > 0 && compSize > 0)
             {
                 try
                 {
@@ -721,21 +697,22 @@ namespace CrossArc
                 }
             }
 
-            if (DecompSize != data.Length)
+            if (decompSize != data.Length)
                 Console.WriteLine("Error: Filesize mismatch ");
 
             return data;
         }
 
 
-        public static byte[] GetFileData(long Offset, long CompSize, long DecompSize)
+        public byte[] GetFileData(long offset, long compSize, long decompSize)
         {
-            using (BinaryReader R = new BinaryReader(new FileStream(FilePath, FileMode.Open)))
+            using (BinaryReader r = new BinaryReader(new FileStream(FilePath, FileMode.Open)))
             {
-                return GetFileData(R, Offset, CompSize, DecompSize);
+                return GetFileData(r, offset, compSize, decompSize);
             }
         }
 
+        // TODO: Move this method
         public static byte[] Decompress(byte[] compressed)
         {
             using (var memoryStream = new MemoryStream(compressed))
@@ -747,41 +724,41 @@ namespace CrossArc
             }
         }
 
-        public static FileOffsetGroup GetOffsetFromSubFile(_sFileInformation FileInfo)
+        private FileOffsetGroup GetOffsetFromSubFile(_sFileInformation fileInfo)
         {
             FileOffsetGroup g = new FileOffsetGroup();
-            int SubIndex = (int)FileInfo.SubFile_Index;
-            _SubFileInfo subfile = SubFileInformation_1[SubIndex];
+            int subIndex = (int)fileInfo.SubFile_Index;
+            _SubFileInfo subfile = subFileInformation1[subIndex];
 
             int flag = ((int)subfile.Flags >> 24);
-            bool UseTable2 = (flag & 0xFF) == 0x08 || (flag & 0xFF) == 0x0B;
-            int ExternalOffset = (int)subfile.Flags & 0xFFFFFF;
+            bool useTable2 = (flag & 0xFF) == 0x08 || (flag & 0xFF) == 0x0B;
+            int externalOffset = (int)subfile.Flags & 0xFFFFFF;
 
-            if (flag == 0x03 && ExternalOffset > 0)
+            if (flag == 0x03 && externalOffset > 0)
             {
                 //Debug.WriteLine("\tEmpty?------------");
                 //Debug.WriteLine("\t\t" + subfile.Offset.ToString("X") + " " + subfile.CompSize.ToString("X") + " " + subfile.DecompSize.ToString("X"));
             }
 
-            if (ExternalOffset > 0 && !UseTable2)
+            if (externalOffset > 0 && !useTable2)
             {
                 //Debug.WriteLine("\t\t External ->" + GetName(FileInformation[ExternalOffset].Hash2));
-                return GetOffsetFromSubFile(FileInformation[ExternalOffset]);
+                return GetOffsetFromSubFile(fileInformation[externalOffset]);
             }
-            Dictionary<int, _sDirectoryOffsets> Offsets = ChunkHash1;
-            if (UseTable2)
+            Dictionary<int, _sDirectoryOffsets> offsets = chunkHash1;
+            if (useTable2)
             {
-                Offsets = ChunkHash2;
-                SubIndex = (int)(subfile.Flags & 0xFFFFFF);
-                subfile = SubFileInformation_2[SubIndex];
+                offsets = chunkHash2;
+                subIndex = (int)(subfile.Flags & 0xFFFFFF);
+                subfile = subFileInformation2[subIndex];
             }
 
             //foreach (_sFileChunkOffsets chunk in Offsets)
-            _sDirectoryOffsets chunk = Offsets[SubIndex];
+            _sDirectoryOffsets chunk = offsets[subIndex];
             {
-                if (SubIndex >= chunk.SubDataStartIndex && SubIndex < chunk.SubDataStartIndex + chunk.SubDataCount)
+                if (subIndex >= chunk.SubDataStartIndex && subIndex < chunk.SubDataStartIndex + chunk.SubDataCount)
                 {
-                    g.ArcOffset = new long[] { (Header.FileSectionOffset + chunk.Offset + (subfile.Offset << 2)) };
+                    g.ArcOffset = new long[] { (header.FileSectionOffset + chunk.Offset + (subfile.Offset << 2)) };
                     g.Offset = new long[] { subfile.Offset };// (Header.FileSectionOffset + chunk.Offset + (subfile.Offset << 2));
                     g.CompSize = new long[] { subfile.CompSize };
                     g.DecompSize = new long[] { subfile.DecompSize };
@@ -793,37 +770,37 @@ namespace CrossArc
             return g;
         }
 
-        public static string GetPathString(Dictionary<uint, _sDirectoryList> HashBank, _sDirectoryList Folder)
+        public static string GetPathString(Dictionary<uint, _sDirectoryList> hashBank, _sDirectoryList folder)
         {
-            string Folder1 = "";
-            string Folder2 = "";
-            string Folder3 = "";
+            string folder1 = "";
+            string folder2 = "";
+            string folder3 = "";
 
-            if (Folder.HashID != Folder.NameHash && Folder.NameHash != 0 && HashBank.ContainsKey(Folder.NameHash))
-                Folder3 = GetPathString(HashBank, HashBank[Folder.NameHash]) + "/";
-            else if (Folder.NameHash != 0)
-                Folder3 = GetName(Folder.NameHash);
+            if (folder.HashID != folder.NameHash && folder.NameHash != 0 && hashBank.ContainsKey(folder.NameHash))
+                folder3 = GetPathString(hashBank, hashBank[folder.NameHash]) + "/";
+            else if (folder.NameHash != 0)
+                folder3 = GetName(folder.NameHash);
 
-            if (HashBank.ContainsKey(Folder.Hash4))
-                Folder2 = GetPathString(HashBank, HashBank[Folder.Hash4]) + "/";
-            else if (Folder.Hash4 != 0)
-                Folder3 = GetName(Folder.Hash4);
+            if (hashBank.ContainsKey(folder.Hash4))
+                folder2 = GetPathString(hashBank, hashBank[folder.Hash4]) + "/";
+            else if (folder.Hash4 != 0)
+                folder3 = GetName(folder.Hash4);
 
             /*if (Folder.Hash4 != 0 && Folder.Hash4 != 0 && HashBank.ContainsKey(Folder.Hash4))
                 Folder1 = GetPathString(HashBank, HashBank[Folder.Hash4]) + "/";
             else if (Folder.Hash4 != 0)
                 Folder3 = GetName(Folder.Hash4);*/
 
-            return Folder1 + Folder2 + Folder3;
+            return folder1 + folder2 + folder3;
         }
 
-
+        // TODO: Move this method
         public static Dictionary<uint, string> MissingHashes = new Dictionary<uint, string>();
         public static Dictionary<uint, string> UsedHashes = new Dictionary<uint, string>();
-        public static string GetName(uint Hash, string Extension = "")
+        public static string GetName(uint hash, string extension = "")
         {
             string name = "";
-            if (HashDict.TryGetValue(Hash, out name))
+            if (HashDict.TryGetValue(hash, out name))
             {
                 //if (!UsedHashes.ContainsKey(Hash))
                 //    UsedHashes.Add(Hash, name);
@@ -832,9 +809,10 @@ namespace CrossArc
 
             //if (!MissingHashes.ContainsKey(Hash))
             //    MissingHashes.Add(Hash, name);
-            return "0x" + Hash.ToString("X") + Extension;
+            return "0x" + hash.ToString("X") + extension;
         }
 
+        // TODO: Move this method
         public static T[] ReadArray<T>(BinaryReader reader, uint size)
         {
             // slow af but whatevs
@@ -846,6 +824,7 @@ namespace CrossArc
             return arr;
         }
 
+        // TODO: Move this method
         public static T ByteToType<T>(BinaryReader reader)
         {
             byte[] bytes = reader.ReadBytes(Marshal.SizeOf(typeof(T)));
@@ -864,86 +843,86 @@ namespace CrossArc
             public uint Hash;
         }
 
-        public static void CompareHashes(string PreviousHashFileName, string CurrentHashFileName)
+        public static void CompareHashes(string previousHashFileName, string currentHashFileName)
         {
-            Dictionary<long, HashCompareCheck> PreviousHashes = new Dictionary<long, HashCompareCheck>();
-            List<HashCompareCheck> Hash2 = new List<HashCompareCheck>();
+            Dictionary<long, HashCompareCheck> previousHashes = new Dictionary<long, HashCompareCheck>();
+            List<HashCompareCheck> hash2 = new List<HashCompareCheck>();
 
-            using (BinaryReader reader = new BinaryReader(new FileStream(PreviousHashFileName, FileMode.Open)))
+            using (BinaryReader reader = new BinaryReader(new FileStream(previousHashFileName, FileMode.Open)))
             {
                 reader.ReadUInt32();
-                uint FileCount = reader.ReadUInt32();
-                FileCount = (uint)(reader.BaseStream.Length - 8) / 12;
-                var Hashes = ReadArray<HashCompareCheck>(reader, FileCount);
-                foreach (var f in Hashes)
+                uint fileCount = reader.ReadUInt32();
+                fileCount = (uint)(reader.BaseStream.Length - 8) / 12;
+                var hashes = ReadArray<HashCompareCheck>(reader, fileCount);
+                foreach (var f in hashes)
                 {
                     long key = ((long)f.Name << 32) | f.Path;
-                    if (!PreviousHashes.ContainsKey(key))
-                        PreviousHashes.Add(key, f);
+                    if (!previousHashes.ContainsKey(key))
+                        previousHashes.Add(key, f);
                     else
                     {
-                        string Path = "";
-                        if (!HashDict.TryGetValue(f.Path, out Path))
-                            Path = "0x" + f.Path.ToString("X");
-                        string Name = "";
-                        if (!HashDict.TryGetValue(f.Name, out Name))
-                            Name = "0x" + f.Name.ToString("X");
-                        Console.WriteLine($"Duplicate: {Path}{Name}");
+                        string path = "";
+                        if (!HashDict.TryGetValue(f.Path, out path))
+                            path = "0x" + f.Path.ToString("X");
+                        string name = "";
+                        if (!HashDict.TryGetValue(f.Name, out name))
+                            name = "0x" + f.Name.ToString("X");
+                        Console.WriteLine($"Duplicate: {path}{name}");
                         //PreviousHashes[key] = f;
                     }
                 }
             }
 
-            using (BinaryReader reader = new BinaryReader(new FileStream(CurrentHashFileName, FileMode.Open)))
+            using (BinaryReader reader = new BinaryReader(new FileStream(currentHashFileName, FileMode.Open)))
             {
                 reader.ReadUInt32();
-                uint FileCount = reader.ReadUInt32();
-                FileCount = (uint)(reader.BaseStream.Length - 8) / 12;
-                var Hashes = ReadArray<HashCompareCheck>(reader, FileCount);
-                Dictionary<long, object> Keys = new Dictionary<long, object>();
-                foreach (var f in Hashes)
+                uint fileCount = reader.ReadUInt32();
+                fileCount = (uint)(reader.BaseStream.Length - 8) / 12;
+                var hashes = ReadArray<HashCompareCheck>(reader, fileCount);
+                Dictionary<long, object> keys = new Dictionary<long, object>();
+                foreach (var f in hashes)
                 {
                     long key = ((long)f.Name << 32) | f.Path;
-                    if (!Keys.ContainsKey(key))
+                    if (!keys.ContainsKey(key))
                     {
-                        Hash2.Add(f);
-                        Keys.Add(key, f);
+                        hash2.Add(f);
+                        keys.Add(key, f);
                     }
                 }
             }
 
-            List<string> Changed = new List<string>();
+            List<string> changed = new List<string>();
             List<string> New = new List<string>();
 
 
             int count = 0;
-            int Percent = 1;
+            int percent = 1;
 
-            foreach (HashCompareCheck c in Hash2)
+            foreach (HashCompareCheck c in hash2)
             {
                 count++;
-                if (count == Hash2.Count / 100)
+                if (count == hash2.Count / 100)
                 {
-                    Console.WriteLine($"{Percent}% done");
-                    Percent++;
+                    Console.WriteLine($"{percent}% done");
+                    percent++;
                     count = 0;
                 }
-                string Path = "";
-                if (!HashDict.TryGetValue(c.Path, out Path))
-                    Path = "0x" + c.Path.ToString("X");
-                string Name = "";
-                if (!HashDict.TryGetValue(c.Name, out Name))
-                    Name = "0x" + c.Name.ToString("X");
+                string path = "";
+                if (!HashDict.TryGetValue(c.Path, out path))
+                    path = "0x" + c.Path.ToString("X");
+                string name = "";
+                if (!HashDict.TryGetValue(c.Name, out name))
+                    name = "0x" + c.Name.ToString("X");
                 long key = ((long)c.Name << 32) | c.Path;
-                if (PreviousHashes.ContainsKey(key))
+                if (previousHashes.ContainsKey(key))
                 {
-                    if (PreviousHashes[key].Hash != c.Hash)
-                        Changed.Add(Path + Name);
-                    PreviousHashes.Remove(key);
+                    if (previousHashes[key].Hash != c.Hash)
+                        changed.Add(path + name);
+                    previousHashes.Remove(key);
                 }
                 else
                 {
-                    New.Add(Path + Name);
+                    New.Add(path + name);
                 }
             }
 
@@ -953,36 +932,36 @@ namespace CrossArc
                 {
                     writer.WriteLine($"Added: {f}");
                 }
-                foreach (var f in Changed)
+                foreach (var f in changed)
                 {
                     writer.WriteLine($"Changed: {f}");
                 }
             }
         }
 
-        public static void CreateHashCompare(string outFileName)
+        public void CreateHashCompare(string outFileName)
         {
             using (BinaryReader reader = new BinaryReader(new FileStream(FilePath, FileMode.Open)))
             {
                 using (BinaryWriter writer = new BinaryWriter(new FileStream(outFileName, FileMode.Create)))
                 {
-                    var Files = GetFiles();
+                    var files = GetFiles();
                     writer.Write("CRCH".ToCharArray());
-                    writer.Write(Files.Count);
-                    int PercentSlice = Files.Count / 100;
-                    int FileCount = 0;
-                    int Percent = 0;
-                    foreach (var file in Files)
+                    writer.Write(files.Count);
+                    int percentSlice = files.Count / 100;
+                    int fileCount = 0;
+                    int percent = 0;
+                    foreach (var file in files)
                     {
-                        if (FileCount >= PercentSlice)
+                        if (fileCount >= percentSlice)
                         {
-                            FileCount = 0;
-                            Console.WriteLine($"{Percent}% Done");
-                            Percent++;
+                            fileCount = 0;
+                            Console.WriteLine($"{percent}% Done");
+                            percent++;
                         }
                         if (file.CompSize[0] == 0 && file.DecompSize[0] == 0)
                             continue;
-                        FileCount++;
+                        fileCount++;
                         writer.Write(file.FileNameHash);
                         writer.Write(file.PathHash);
                         reader.BaseStream.Position = file.ArcOffset[0];
@@ -990,7 +969,7 @@ namespace CrossArc
                         writer.Write(CRC32.Crc32C(data));
                     }
                     writer.BaseStream.Position = 4;
-                    writer.Write(FileCount);
+                    writer.Write(fileCount);
                 }
             }
 

--- a/CrossArc/ArcArrayReading.cs
+++ b/CrossArc/ArcArrayReading.cs
@@ -1,0 +1,223 @@
+﻿using CrossArc.Structs;
+using System.IO;
+
+namespace CrossArc
+{
+    /// <summary>
+    /// Contains methods for reading arrays of specific structs.
+    /// Parsing structs manually using a binary reader is verbose but has a noticeable performance improvement.
+    /// </summary>
+    internal static class ArcArrayReading
+    {
+        public static _sFileInformationPath[] ReadSFileInformationPaths(BinaryReader reader, uint count)
+        {
+            _sFileInformationPath[] array = new _sFileInformationPath[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _sFileInformationPath
+                {
+                    Path = reader.ReadUInt32(),
+                    DirectoryIndex = reader.ReadUInt32(),
+                    Extension = reader.ReadUInt32(),
+                    FileTableFlag = reader.ReadUInt32(),
+                    Parent = reader.ReadUInt32(),
+                    Unk5 = reader.ReadUInt32(),
+                    Hash2 = reader.ReadUInt32(),
+                    Unk6 = reader.ReadUInt32()
+                };
+            }
+
+            return array;
+        }
+
+        public static _sStreamIndexToFile[] ReadSStreamIndicesToFiles(BinaryReader reader, uint count)
+        {
+            _sStreamIndexToFile[] array = new _sStreamIndexToFile[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _sStreamIndexToFile
+                {
+                    FileIndex = reader.ReadInt32()
+                };
+            }
+
+            return array;
+        }
+
+        public static _sStreamNameToHash[] ReadSStreamNamesToHashes(BinaryReader reader, uint count)
+        {
+            _sStreamNameToHash[] array = new _sStreamNameToHash[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _sStreamNameToHash
+                {
+                    Hash = reader.ReadUInt32(),
+                    NameIndex = reader.ReadUInt32(),
+                    Flags = reader.ReadUInt32()
+                };
+            }
+
+            return array;
+        }
+
+        public static _sStreamOffset[] ReadSStreamOffsets(BinaryReader reader, uint count)
+        {
+            _sStreamOffset[] array = new _sStreamOffset[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _sStreamOffset
+                {
+                    Size = reader.ReadInt64(),
+                    Offset = reader.ReadInt64()
+                };
+            }
+
+            return array;
+        }
+
+        public static _sDirectoryList[] ReadSDirectoryLists(BinaryReader reader, uint count)
+        {
+            _sDirectoryList[] array = new _sDirectoryList[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _sDirectoryList
+                {
+                    HashID = reader.ReadUInt32(),
+                    DirOffsetIndex = reader.ReadUInt32(),
+                    NameHash = reader.ReadUInt32(),
+                    ParentHash = reader.ReadUInt32(),
+
+                    Hash4 = reader.ReadUInt32(),
+                    FirstFilIndex = reader.ReadUInt32(),
+                    unk = reader.ReadUInt32(),
+                    FirstFileIndex = reader.ReadUInt32(),
+
+                    FileInformationStartIndex = reader.ReadUInt32(),
+                    FileInformationCount = reader.ReadUInt32(),
+                    FileNameStartIndex = reader.ReadUInt32(),
+                    FileNameCount = reader.ReadInt16(),
+                    Unk4 = reader.ReadUInt16(),
+
+                    Unk5 = reader.ReadUInt32()
+                };
+            }
+
+            return array;
+        }
+
+        public static _sDirectoryOffsets[] ReadDirectoryOffsets(BinaryReader reader, uint count)
+        {
+            _sDirectoryOffsets[] array = new _sDirectoryOffsets[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _sDirectoryOffsets
+                {
+                    Offset = reader.ReadInt64(),
+                    DecompSize = reader.ReadUInt32(),
+                    Size = reader.ReadUInt32(),
+                    SubDataStartIndex = reader.ReadUInt32(),
+                    SubDataCount = reader.ReadUInt32(),
+                    ResourceIndex = reader.ReadUInt32(),
+                };
+            }
+
+            return array;
+        }
+
+        public static _sFolderHashIndex[] ReadSFolderHashIndices(BinaryReader reader, uint count)
+        {
+            _sFolderHashIndex[] array = new _sFolderHashIndex[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _sFolderHashIndex
+                {
+                    Hash = reader.ReadUInt32(),
+                    Count = reader.ReadUInt32()
+                };
+            }
+
+            return array;
+        }
+
+        public static _sFileInformationIndex[] ReadSFileInformationIndices(BinaryReader reader, uint count)
+        {
+            _sFileInformationIndex[] array = new _sFileInformationIndex[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _sFileInformationIndex
+                {
+                    SomeIndex1 = reader.ReadUInt32(),
+                    SomeIndex2 = reader.ReadUInt32()
+                };
+            }
+
+            return array;
+        }
+
+        public static _sFileInformationV2[] ReadSFileInformationV2(BinaryReader reader, uint count)
+        {
+            _sFileInformationV2[] array = new _sFileInformationV2[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _sFileInformationV2
+                {
+                    HashIndex = reader.ReadUInt32(),
+                    HashIndex2 = reader.ReadUInt32(),
+                    SubFile_Index = reader.ReadUInt32(),
+                    Flags = reader.ReadUInt32()
+                };
+            }
+
+            return array;
+        }
+
+        public static _sFileInformationSubIndex[] ReadSFileInformationSubIndices(BinaryReader reader, uint count)
+        {
+            _sFileInformationSubIndex[] array = new _sFileInformationSubIndex[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _sFileInformationSubIndex
+                {
+                    SomeIndex1 = reader.ReadUInt32(),
+                    SomeIndex2 = reader.ReadUInt32(),
+                    SomeIndex3 = reader.ReadUInt32()
+                };
+            }
+
+            return array;
+        }
+
+        public static _SubFileInfo[] ReadSubFileInfos(BinaryReader reader, uint count)
+        {
+            _SubFileInfo[] array = new _SubFileInfo[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _SubFileInfo
+                {
+                    Offset = reader.ReadUInt32(),
+                    CompSize = reader.ReadUInt32(),
+                    DecompSize = reader.ReadUInt32(),
+                    Flags = reader.ReadUInt32()
+                };
+            }
+
+            return array;
+        }
+
+
+        public static _sHashInt[] ReadHashInts(BinaryReader reader, uint count)
+        {
+            _sHashInt[] array = new _sHashInt[count];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = new _sHashInt
+                {
+                    Hash = reader.ReadUInt32(),
+                    Index = reader.ReadUInt32()
+                };
+            }
+
+            return array;
+        }
+    }
+}

--- a/CrossArc/CrossArc.csproj
+++ b/CrossArc/CrossArc.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ARC.cs" />
+    <Compile Include="ArcArrayReading.cs" />
     <Compile Include="CRC32.cs" />
     <Compile Include="Form1.cs">
       <SubType>Form</SubType>

--- a/CrossArc/Form1.cs
+++ b/CrossArc/Form1.cs
@@ -9,59 +9,41 @@ namespace CrossArc
 {
     public partial class Form1 : Form
     {
-        private FolderNode Root = new FolderNode("root");
-        private FolderNode Stream = new FolderNode("stream");
+        private readonly FolderNode rootNode;
+        private readonly FolderNode streamNode;
+
+        private readonly ARC arc;
 
         public static int SelectedRegion = 0;
 
-        public static ContextMenu NodeContextMenu
-        {
-            get
-            {
-                if (_nodeContextMenu == null)
-                {
-                    _nodeContextMenu = new ContextMenu();
+        public ContextMenu NodeContextMenu { get; }
 
-                    MenuItem Ex = new MenuItem("Extract");
-                    Ex.Click += Extract;
-                    _nodeContextMenu.MenuItems.Add(Ex);
-
-                    MenuItem Exc = new MenuItem("Extract Compressed");
-                    Exc.Click += ExtractCompressed;
-                    _nodeContextMenu.MenuItems.Add(Exc);
-                }
-                return _nodeContextMenu;
-            }
-        }
-        public static ContextMenu _nodeContextMenu;
-
-        public static void Extract(object sender, EventArgs args)
+        public void Extract(object sender, EventArgs args)
         {
             TreeNode node = Form1.fileTree.SelectedNode;
             if (node == null)
             {
                 return;
             }
-            if (node is FolderNode foldernode)
+            if (node is FolderNode folderNode)
             {
-                var info = foldernode.GetExtractInformation();
+                var info = folderNode.GetExtractInformation(false);
 
-                ExtractProgressBar pb = new ExtractProgressBar();
+                ExtractProgressBar pb = new ExtractProgressBar(arc);
                 pb.Show();
                 pb.Extract(info);
             }
-            if (node is FileNode filenode)
+            if (node is FileNode fileNode)
             {
-                var info = filenode.GetExtractInformation(filenode.FullFilePath);
+                var info = fileNode.GetExtractInformation(fileNode.FullFilePath);
 
-                ExtractProgressBar pb = new ExtractProgressBar();
+                ExtractProgressBar pb = new ExtractProgressBar(arc);
                 pb.Show();
                 pb.Extract(info);
             }
         }
 
-
-        public static void ExtractFolder(object sender, EventArgs args)
+        public void ExtractFolder(object sender, EventArgs args)
         {
             TreeNode node = Form1.fileTree.SelectedNode;
             if (node == null)
@@ -70,15 +52,15 @@ namespace CrossArc
             }
             if (node is FolderNode)
             {
-                ((FolderNode)node).ExtractFolder();
+                ((FolderNode)node).ExtractFolder(arc, false);
             }
             if (node is FileNode)
             {
-                ((FileNode)node).ExtractFolder();
+                ((FileNode)node).ExtractFolder(arc, false);
             }
         }
 
-        public static void ExtractCompressed(object sender, EventArgs args)
+        public void ExtractCompressed(object sender, EventArgs args)
         {
             TreeNode node = Form1.fileTree.SelectedNode;
             if (node == null)
@@ -89,7 +71,7 @@ namespace CrossArc
             {
                 var info = foldernode.GetExtractInformation(true);
 
-                ExtractProgressBar pb = new ExtractProgressBar();
+                ExtractProgressBar pb = new ExtractProgressBar(arc);
                 pb.Show();
                 pb.Extract(info);
             }
@@ -97,13 +79,13 @@ namespace CrossArc
             {
                 var info = filenode.GetExtractInformation(filenode.FullFilePath, true);
 
-                ExtractProgressBar pb = new ExtractProgressBar();
+                ExtractProgressBar pb = new ExtractProgressBar(arc);
                 pb.Show();
                 pb.Extract(info);
             }
         }
 
-        public static void ExtractCompressedFolder(object sender, EventArgs args)
+        public void ExtractCompressedFolder(object sender, EventArgs args)
         {
             TreeNode node = Form1.fileTree.SelectedNode;
             if (node == null)
@@ -112,11 +94,11 @@ namespace CrossArc
             }
             if (node is FolderNode)
             {
-                ((FolderNode)node).ExtractFolder();
+                ((FolderNode)node).ExtractFolder(arc, true);
             }
             if (node is FileNode)
             {
-                ((FileNode)node).ExtractFolder();
+                ((FileNode)node).ExtractFolder(arc, true);
             }
         }
 
@@ -124,44 +106,53 @@ namespace CrossArc
         {
             InitializeComponent();
 
-            fileTree.BeforeExpand += folderTree_BeforeExpand;
+            NodeContextMenu = new ContextMenu();
 
-            fileTree.NodeMouseClick += (sender, args) => fileTree.SelectedNode = args.Node;
+            MenuItem extract = new MenuItem("Extract");
+            extract.Click += Extract;
+            NodeContextMenu.MenuItems.Add(extract);
 
-            fileTree.HideSelection = false;
+            MenuItem extractCompressed = new MenuItem("Extract Compressed");
+            extractCompressed.Click += ExtractCompressed;
+            NodeContextMenu.MenuItems.Add(extractCompressed);
 
-            fileTree.ImageList = new ImageList();
-            fileTree.ImageList.Images.Add("folder", Properties.Resources.folder);
-            fileTree.ImageList.Images.Add("file", Properties.Resources.file);
+            rootNode = new FolderNode("root", NodeContextMenu);
+            streamNode = new FolderNode("stream", NodeContextMenu);
 
-            regionCB.SelectedIndex = 0;
+            InitializeGui();
 
-            // Files
+            var path = GetArcPath();
+            arc = new ARC(path);
+
+            // TODO: This step is very slow.
+            InitializeTreeView();
+        }
+
+        private void InitializeTreeView()
+        {
             long TotalSize = 0;
             var timer = new Stopwatch();
             timer.Start();
-            if (ARC.FileInformation != null || ARC.FileInformationV2 != null)
+
+            foreach (FileOffsetGroup g in arc.GetFiles())
             {
-                foreach (FileOffsetGroup g in ARC.GetFiles())
-                {
-                    FolderNode Folder = (FolderNode)GetFolderFromPath(g.Path, Root);
-                    if (g.CompSize == null)
-                        continue;
+                FolderNode Folder = (FolderNode)GetFolderFromPath(g.Path, rootNode);
+                if (g.CompSize == null)
+                    continue;
 
-                    FileNode fNode = CreateFileNode(g);
+                FileNode fNode = CreateFileNode(g);
 
-                    TotalSize += fNode.DecompSize;
+                TotalSize += fNode.DecompSize;
 
-                    if (!Folder.NodesByName.ContainsKey(fNode.Text))
-                        Folder.NodesByName.Add(fNode.Text, new List<TreeNode>());
-                    Folder.NodesByName[fNode.Text].Add(fNode);
-                }
+                if (!Folder.NodesByName.ContainsKey(fNode.Text))
+                    Folder.NodesByName.Add(fNode.Text, new List<TreeNode>());
+                Folder.NodesByName[fNode.Text].Add(fNode);
             }
 
-            foreach (var g in ARC.GetStreamFiles())
+            foreach (var g in arc.GetStreamFiles())
             {
                 string FPath = g.FileName.Replace("stream:/", "");
-                FolderNode Folder = (FolderNode)GetFolderFromPath(Path.GetDirectoryName(FPath).Replace("\\", "/"), Stream);
+                FolderNode Folder = (FolderNode)GetFolderFromPath(Path.GetDirectoryName(FPath).Replace("\\", "/"), streamNode);
 
                 FileNode fNode = CreateFileNodeFromStreamFile(g, FPath);
 
@@ -175,55 +166,90 @@ namespace CrossArc
             Debug.WriteLine("Total File Size: " + FormatBytes(TotalSize));
 
             fileTree.BeginUpdate();
-            fileTree.Nodes.Add(Root);
-            fileTree.Nodes.Add(Stream);
+            fileTree.Nodes.Add(rootNode);
+            fileTree.Nodes.Add(streamNode);
             fileTree.EndUpdate();
         }
 
-        private static FileNode CreateFileNodeFromStreamFile(FileOffsetGroup g, string FPath)
+        private void InitializeGui()
         {
-            FileNode fNode = new FileNode(Path.GetFileName(FPath))
+            fileTree.BeforeExpand += folderTree_BeforeExpand;
+
+            fileTree.NodeMouseClick += (sender, args) => fileTree.SelectedNode = args.Node;
+
+            fileTree.HideSelection = false;
+
+            fileTree.ImageList = new ImageList();
+            fileTree.ImageList.Images.Add("folder", Properties.Resources.folder);
+            fileTree.ImageList.Images.Add("file", Properties.Resources.file);
+
+            regionCB.SelectedIndex = 0;
+        }
+
+        private static string GetArcPath()
+        {
+            if (!File.Exists("data.arc"))
             {
-                ArcOffset = g.ArcOffset[0],
-                CompSize = (uint)g.CompSize[0],
-                DecompSize = (uint)g.DecompSize[0],
-                Flags = g.Flags[0],
-                FullFilePath = FPath
+                using (OpenFileDialog d = new OpenFileDialog())
+                {
+                    d.Title = "Select your data.arc file";
+                    d.FileName = "data.arc";
+                    d.Filter = "Smash Ultimate ARC (*.arc)|*.arc";
+
+                    if (d.ShowDialog() == DialogResult.OK)
+                    {
+                        return d.FileName;
+                    }
+                }
+            }
+
+            return "data.arc";
+        }
+
+        private FileNode CreateFileNodeFromStreamFile(FileOffsetGroup fileOffsetGroup, string filePath)
+        {
+            FileNode fNode = new FileNode(Path.GetFileName(filePath), NodeContextMenu)
+            {
+                ArcOffset = fileOffsetGroup.ArcOffset[0],
+                CompSize = (uint)fileOffsetGroup.CompSize[0],
+                DecompSize = (uint)fileOffsetGroup.DecompSize[0],
+                Flags = fileOffsetGroup.Flags[0],
+                FullFilePath = filePath
             };
 
-            if ((g.ArcOffset.Length > 1))
+            if ((fileOffsetGroup.ArcOffset.Length > 1))
             {
                 fNode.IsRegional = true;
-                fNode._rArcOffset = g.ArcOffset;
-                fNode._rCompSize = g.CompSize;
-                fNode._rDecompSize = g.DecompSize;
-                fNode._rFlags = g.Flags;
-                fNode.FullFilePath = FPath;
+                fNode._rArcOffset = fileOffsetGroup.ArcOffset;
+                fNode._rCompSize = fileOffsetGroup.CompSize;
+                fNode._rDecompSize = fileOffsetGroup.DecompSize;
+                fNode._rFlags = fileOffsetGroup.Flags;
+                fNode.FullFilePath = filePath;
             }
 
             return fNode;
         }
 
-        private static FileNode CreateFileNode(FileOffsetGroup g)
+        private FileNode CreateFileNode(FileOffsetGroup fileOffsetGroup)
         {
-            FileNode fNode = new FileNode(g.FileName)
+            FileNode fNode = new FileNode(fileOffsetGroup.FileName, NodeContextMenu)
             {
-                ArcOffset = g.ArcOffset[0],
-                CompSize = (uint)g.CompSize[0],
-                DecompSize = (uint)g.DecompSize[0],
-                Flags = g.Flags[0],
-                FullFilePath = g.Path + g.FileName
+                ArcOffset = fileOffsetGroup.ArcOffset[0],
+                CompSize = (uint)fileOffsetGroup.CompSize[0],
+                DecompSize = (uint)fileOffsetGroup.DecompSize[0],
+                Flags = fileOffsetGroup.Flags[0],
+                FullFilePath = fileOffsetGroup.Path + fileOffsetGroup.FileName
             };
 
-            if ((g.ArcOffset.Length > 1))
+            if ((fileOffsetGroup.ArcOffset.Length > 1))
             {
 
                 fNode.IsRegional = true;
-                fNode._rArcOffset = g.ArcOffset;
-                fNode._rCompSize = g.CompSize;
-                fNode._rDecompSize = g.DecompSize;
-                fNode._rFlags = g.Flags;
-                fNode.FullFilePath = g.Path + g.FileName;
+                fNode._rArcOffset = fileOffsetGroup.ArcOffset;
+                fNode._rCompSize = fileOffsetGroup.CompSize;
+                fNode._rDecompSize = fileOffsetGroup.DecompSize;
+                fNode._rFlags = fileOffsetGroup.Flags;
+                fNode.FullFilePath = fileOffsetGroup.Path + fileOffsetGroup.FileName;
             }
 
             return fNode;
@@ -258,7 +284,7 @@ namespace CrossArc
                 {
                     if (file.Text.EndsWith(extension))
                     {
-                        file.Extract(false);
+                        file.Extract(arc, false);
                     }
                 }
             }
@@ -277,7 +303,7 @@ namespace CrossArc
                         {
                             if (file.Text.EndsWith(extension))
                             {
-                                file.Extract(false);
+                                file.Extract(arc, false);
                             }
                         }
                     }
@@ -288,7 +314,7 @@ namespace CrossArc
         public void MKDir(string path)
         {
             string[] levels = path.Split('/');
-            var subnodes = Root.NodesByName;
+            var subnodes = rootNode.NodesByName;
             for (int i = 0; i < levels.Length; i++)
             {
                 if (levels[i].Equals(""))
@@ -296,7 +322,7 @@ namespace CrossArc
                 FolderNode folder = (FolderNode)FindFolder(levels[i], subnodes);
                 if (folder == null)
                 {
-                    folder = new FolderNode(levels[i]);
+                    folder = new FolderNode(levels[i], NodeContextMenu);
                     subnodes[folder.Text].Add(folder);
                 }
                 subnodes = folder.NodesByName;
@@ -316,7 +342,7 @@ namespace CrossArc
                 folderNode = (FolderNode)FindFolder(levels[i], subnodes);
                 if (folderNode == null)
                 {
-                    FolderNode newFolder = new FolderNode(levels[i]);
+                    FolderNode newFolder = new FolderNode(levels[i], NodeContextMenu);
                     if (!subnodes.ContainsKey(newFolder.Text))
                         subnodes.Add(newFolder.Text, new List<TreeNode>());
                     subnodes[newFolder.Text].Add(newFolder);
@@ -326,7 +352,7 @@ namespace CrossArc
             }
 
             if (folderNode == null)
-                folderNode = new FolderNode(path);
+                folderNode = new FolderNode(path, NodeContextMenu);
 
             return folderNode;
         }

--- a/CrossArc/Form1.cs
+++ b/CrossArc/Form1.cs
@@ -217,7 +217,7 @@ namespace CrossArc
                 FullFilePath = filePath
             };
 
-            if ((fileOffsetGroup.ArcOffset.Length > 1))
+            if ((fileOffsetGroup.IsRegional))
             {
                 fNode.IsRegional = true;
                 fNode._rArcOffset = fileOffsetGroup.ArcOffset;
@@ -241,9 +241,8 @@ namespace CrossArc
                 FullFilePath = fileOffsetGroup.Path + fileOffsetGroup.FileName
             };
 
-            if ((fileOffsetGroup.ArcOffset.Length > 1))
+            if ((fileOffsetGroup.IsRegional))
             {
-
                 fNode.IsRegional = true;
                 fNode._rArcOffset = fileOffsetGroup.ArcOffset;
                 fNode._rCompSize = fileOffsetGroup.CompSize;

--- a/CrossArc/GUI/FolderNode.cs
+++ b/CrossArc/GUI/FolderNode.cs
@@ -16,13 +16,12 @@ namespace CrossArc.GUI
         // Some files may have the same name, so we need to store a list of nodes.
         public Dictionary<string, List<TreeNode>> NodesByName { get; } = new Dictionary<string, List<TreeNode>>();
 
-        public FolderNode(string text)
+        public FolderNode(string text, ContextMenu menu)
         {
             Text = text;
-            ContextMenu = Form1.NodeContextMenu;
+            ContextMenu = menu;
             AfterCollapse();
         }
-
 
         public void BeforeExpand()
         {
@@ -42,7 +41,7 @@ namespace CrossArc.GUI
             Nodes.Add(new TreeNode("Dummy"));
         }
 
-        public ArcExtractInformation[] GetExtractInformation(bool compressed = false)
+        public ArcExtractInformation[] GetExtractInformation(bool preserveCompression)
         {
             Queue<TreeNode> NodeList = new Queue<TreeNode>();
             List<ArcExtractInformation> info = new List<ArcExtractInformation>();
@@ -60,7 +59,7 @@ namespace CrossArc.GUI
                 TreeNode n = NodeList.Dequeue();
                 if (n is FileNode fileNode)
                 {
-                    info.AddRange(fileNode.GetExtractInformation(fileNode.FullFilePath, compressed));
+                    info.AddRange(fileNode.GetExtractInformation(fileNode.FullFilePath, preserveCompression));
                 }
                 else
                 {
@@ -77,7 +76,7 @@ namespace CrossArc.GUI
             return info.ToArray();
         }
 
-        public void Extract(bool compressed = false)
+        public void Extract(ARC arc, bool preserveCompression)
         {
             Queue<TreeNode> NodeList = new Queue<TreeNode>();
 
@@ -90,7 +89,7 @@ namespace CrossArc.GUI
                 TreeNode n = NodeList.Dequeue();
                 if (n is FileNode)
                 {
-                    ((FileNode)n).Extract(compressed);
+                    ((FileNode)n).Extract(arc, preserveCompression);
                 }
                 else
                 {
@@ -99,7 +98,8 @@ namespace CrossArc.GUI
                 }
             }
         }
-        public void ExtractFolder(bool compressed = false)
+
+        public void ExtractFolder(ARC arc, bool preserveCompression)
         {
             using (SaveFileDialog d = new SaveFileDialog())
             {
@@ -111,7 +111,7 @@ namespace CrossArc.GUI
                     {
                         if(f is FileNode)
                         {
-                            ((FileNode)f).SaveFile(Path.GetDirectoryName(d.FileName) + "/" + f.Text, compressed);
+                            ((FileNode)f).SaveFile(Path.GetDirectoryName(d.FileName) + "/" + f.Text, arc, preserveCompression);
                         }
                     }
                 }

--- a/CrossArc/GUI/ProgressBar.cs
+++ b/CrossArc/GUI/ProgressBar.cs
@@ -7,10 +7,12 @@ namespace CrossArc.GUI
 {
     public partial class ExtractProgressBar : Form
     {
+        private readonly ARC arc;
         private ArcExtractInformation[] toExtract;
 
-        public ExtractProgressBar()
+        public ExtractProgressBar(ARC arc)
         {
+            this.arc = arc;
             InitializeComponent();
             TopMost = true;
         }
@@ -42,7 +44,7 @@ namespace CrossArc.GUI
         private void ExtractFileInformation()
         {
             int index = 0;
-            using (BinaryReader r = new BinaryReader(new FileStream(ARC.FilePath, FileMode.Open)))
+            using (BinaryReader r = new BinaryReader(new FileStream(arc.FilePath, FileMode.Open)))
             {
                 foreach (var file in toExtract)
                 {

--- a/CrossArc/Program.cs
+++ b/CrossArc/Program.cs
@@ -62,15 +62,7 @@ namespace CrossArc
                 Debug.WriteLine("Initiating Hash Dict: " + timer.ElapsedMilliseconds);
                 timer.Reset();
                 timer.Start();
-                try
-                {
-                    ARC.Open();
-                }
-                catch (Exception e)
-                {
-                    MessageBox.Show("Error Opening Arc", e.ToString());
-                    Application.Exit();
-                }
+
                 Application.Run(new Form1());
             }
             else
@@ -79,9 +71,6 @@ namespace CrossArc
             }
             
         }
-
-
-        
 
         public static void PrintStruct<T>(T Struct) where T : struct
         {

--- a/CrossArc/Program.cs
+++ b/CrossArc/Program.cs
@@ -14,8 +14,6 @@ namespace CrossArc
             string ArcOffset = "data.arc";
             string FolderToExtract = "";
 
-            //args = new string[] { "-x", "data.arc" };//, "stage/BossStage_Dracula/normal/model/bs_dc_floor_shadow_set" };
-
             if (args.Length == 0)
             {
                 Console.WriteLine(
@@ -52,21 +50,6 @@ namespace CrossArc
             }
             Debug.WriteLine(FolderToExtract);
 
-            /*var list1 = new List<string>();
-            list1.AddRange(File.ReadAllLines("moosestrings.txt"));
-            list1.Union(File.ReadAllLines("Hashes.txt"));
-            list1.Sort();
-            using (StreamWriter w = new StreamWriter(new FileStream("out.txt", FileMode.Create)))
-            {
-                foreach(string s in list1)
-                w.WriteLine(s);
-            }*/
-
-            //ARC.HashCheck();
-
-            //HashDict.Init();
-            //ARC.CompareHashes("ARCV1_1Hashes.bin", "ARCV2_0Hashes.bin");
-            //return;
             if (!Extract)
             {
                 Application.EnableVisualStyles();
@@ -88,9 +71,6 @@ namespace CrossArc
                     MessageBox.Show("Error Opening Arc", e.ToString());
                     Application.Exit();
                 }
-                timer.Stop();
-                Debug.WriteLine("Initiating Arc: " + timer.ElapsedMilliseconds);
-                //ARC.CreateHashCompare("ARCV2_0Hashes.bin");
                 Application.Run(new Form1());
             }
             else
@@ -98,9 +78,6 @@ namespace CrossArc
                 //ARC.CommandFunctions(FolderToExtract);
             }
             
-            //Console.WriteLine("Done");
-            //Console.WriteLine("Press enter to close");
-            //Console.ReadLine();
         }
 
 


### PR DESCRIPTION
Structs are parsed manually to improve performance considerably. 
ReadArcv2: 986 ms - > 173 ms for debug mode on my desktop using the v3.0 data.arc.
